### PR TITLE
Added missing dependency h5py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ opencv-python==3.4.4.19
 scikit-image==0.14.1
 torch==0.4.1
 tqdm==4.28.1
+h5py


### PR DESCRIPTION
Had to install **h5py** after running `pip3 install -r requirements.txt`.
This request adds **h5py** to _requirements.txt_.